### PR TITLE
Add Agent Skills and MCP Servers section to org README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -10,6 +10,19 @@ Omniverse Workflows and Blueprints provide step-by-step guides and reference imp
 - [Blueprints and Workflows Documentation](https://docs.nvidia.com/omniverse/index.html#blueprints-workflows)
 - [NVIDIA-Omniverse-blueprints on GitHub](https://github.com/NVIDIA-Omniverse-blueprints)
 
+## Agent Skills and MCP Servers
+
+Agent Skills and MCP (Model Context Protocol) servers help AI coding assistants work with Omniverse technologies. Skills provide structured reference docs that agents can load on demand, and MCP servers expose searchable tool APIs for Kit extensions, USD, and OmniUI.
+
+| Name | Type | Description | Repository |
+|------|------|-------------|------------|
+| **ovrtx** | Agent Skills | Omniverse RTX SDK — renderer setup, USD scene loading, rendering, attribute writing, CUDA/Vulkan interop, and project scaffolding. | [NVIDIA-Omniverse/ovrtx/skills/](https://github.com/NVIDIA-Omniverse/ovrtx/tree/main/skills) |
+| **Kit MCP** | MCP Server | Kit development assistant — semantic search across 400+ extensions, dependency graphs, API docs, code examples, and app templates. | [kit-usd-agents/source/mcp/kit_mcp/](https://github.com/NVIDIA-Omniverse/kit-usd-agents/tree/main/source/mcp/kit_mcp) |
+| **USD Code MCP** | MCP Server | USD/OpenUSD development assistant — module and class browsing, method signatures, code examples, and semantic search. | [kit-usd-agents/source/mcp/usd_code_mcp/](https://github.com/NVIDIA-Omniverse/kit-usd-agents/tree/main/source/mcp/usd_code_mcp) |
+| **OmniUI MCP** | MCP Server | OmniUI development assistant — class and module browsing, method docs, code examples, and system instructions. | [kit-usd-agents/source/mcp/omni_ui_mcp/](https://github.com/NVIDIA-Omniverse/kit-usd-agents/tree/main/source/mcp/omni_ui_mcp) |
+
+See also the [NVIDIA Agent Skills catalog](https://github.com/NVIDIA/skills) for skills across the NVIDIA ecosystem.
+
 ## Additional Resources
 
 - [Omniverse Developer Page](https://developer.nvidia.com/omniverse)

--- a/profile/README.md
+++ b/profile/README.md
@@ -17,6 +17,7 @@ Agent Skills and MCP (Model Context Protocol) servers help AI coding assistants 
 | Name | Type | Description | Repository |
 |------|------|-------------|------------|
 | **ovrtx** | Agent Skills | Omniverse RTX SDK — renderer setup, USD scene loading, rendering, attribute writing, CUDA/Vulkan interop, and project scaffolding. | [NVIDIA-Omniverse/ovrtx/skills/](https://github.com/NVIDIA-Omniverse/ovrtx/tree/main/skills) |
+| **ovphysx** | Agent Skills | USD physics simulation — C API with Python bindings, DLPack tensor interop, environment cloning for batched RL, and rigid body simulation. | [NVIDIA-Omniverse/PhysX/ovphysx/](https://github.com/NVIDIA-Omniverse/PhysX/tree/main/ovphysx) |
 | **Kit MCP** | MCP Server | Kit development assistant — semantic search across 400+ extensions, dependency graphs, API docs, code examples, and app templates. | [kit-usd-agents/source/mcp/kit_mcp/](https://github.com/NVIDIA-Omniverse/kit-usd-agents/tree/main/source/mcp/kit_mcp) |
 | **USD Code MCP** | MCP Server | USD/OpenUSD development assistant — module and class browsing, method signatures, code examples, and semantic search. | [kit-usd-agents/source/mcp/usd_code_mcp/](https://github.com/NVIDIA-Omniverse/kit-usd-agents/tree/main/source/mcp/usd_code_mcp) |
 | **OmniUI MCP** | MCP Server | OmniUI development assistant — class and module browsing, method docs, code examples, and system instructions. | [kit-usd-agents/source/mcp/omni_ui_mcp/](https://github.com/NVIDIA-Omniverse/kit-usd-agents/tree/main/source/mcp/omni_ui_mcp) |


### PR DESCRIPTION
## Summary

Adds a new **Agent Skills and MCP Servers** section to the NVIDIA-Omniverse organization profile README, documenting the AI coding assistant resources available across the org:

| Name | Type | Repository |
|------|------|------------|
| **ovrtx** | Agent Skills | [NVIDIA-Omniverse/ovrtx/skills/](https://github.com/NVIDIA-Omniverse/ovrtx/tree/main/skills) |
| **ovphysx** | Agent Skills | [NVIDIA-Omniverse/PhysX/ovphysx/](https://github.com/NVIDIA-Omniverse/PhysX/tree/main/ovphysx) |
| **Kit MCP** | MCP Server | [kit-usd-agents/source/mcp/kit_mcp/](https://github.com/NVIDIA-Omniverse/kit-usd-agents/tree/main/source/mcp/kit_mcp) |
| **USD Code MCP** | MCP Server | [kit-usd-agents/source/mcp/usd_code_mcp/](https://github.com/NVIDIA-Omniverse/kit-usd-agents/tree/main/source/mcp/usd_code_mcp) |
| **OmniUI MCP** | MCP Server | [kit-usd-agents/source/mcp/omni_ui_mcp/](https://github.com/NVIDIA-Omniverse/kit-usd-agents/tree/main/source/mcp/omni_ui_mcp) |

Also links to the [NVIDIA Agent Skills catalog](https://github.com/NVIDIA/skills) for cross-ecosystem discovery.

## Motivation

AI coding assistants (Cursor, Copilot, Claude Code, etc.) are increasingly used for Omniverse development. These Agent Skills and MCP servers are already published in the org but aren't discoverable from the org README. This PR adds visibility.

## Changes

- `profile/README.md`: New section between *Blueprints and Workflows* and *Additional Resources*