### PR TITLE
Update org profile README for standalone Omniverse libraries

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,12 +1,31 @@
 ## Welcome NVIDIA Omniverse on GitHub
 
-The NVIDIA Omniverse GitHub organization contains sample code repositories that demonstrate the use of Omniverse technologies. 
+The NVIDIA Omniverse GitHub organization hosts the standalone Omniverse libraries, OpenUSD tooling and SDKs, and sample code repositories that demonstrate the use of Omniverse technologies.
 
-## Blueprints and Workflows
-Omniverse Workflows and Blueprints provide step-by-step guides and reference implementations for a variety of development scenarios. They can help you get started quickly with use cases such as virtual facility integration (VFI), configurator development, synthetic data generation, and more. These resources build on repositories in this Omniverse GitHub organization.
+## Omniverse Libraries
 
-- [Blueprints and Workflows Documentation](https://docs.nvidia.com/omniverse/index.html#blueprints-workflows)
-- [NVIDIA-Omniverse-blueprints on GitHub](https://github.com/NVIDIA-Omniverse-blueprints)
+Standalone, embeddable libraries that bring core Omniverse technologies to any application. Each provides C and/or Python APIs, and most ship agent skills for AI-assisted development (see [Agent Skills and MCP Servers](#agent-skills-and-mcp-servers) below).
+
+| Library | Description |
+|---------|-------------|
+| [ovrtx](https://github.com/NVIDIA-Omniverse/ovrtx) | A C and Python library for physically accurate, real-time sensor simulation and visualization using NVIDIA Omniverse RTX. |
+| [ovphysx](https://github.com/NVIDIA-Omniverse/PhysX/tree/main/ovphysx) | USD physics simulation built on the NVIDIA PhysX SDK — C API with Python bindings, DLPack tensor interop, and environment cloning for batched reinforcement learning. Part of the [PhysX](https://github.com/NVIDIA-Omniverse/PhysX) repository. |
+| [ovui](https://github.com/NVIDIA-Omniverse/ovui) | The standalone distribution of Omniverse's omni.ui UI framework — a declarative, Python-first API for building hardware-accelerated desktop interfaces backed by ImGui — plus application widget and OpenUSD data-adapter layers. |
+| [ovstream](https://github.com/NVIDIA-Omniverse/ovstream) | C library with Python bindings for streaming video, audio, and input over WebRTC, RTSP, native (StreamSDK), and SHM (shared-memory) transports, with GPU-accelerated NVENC encoding. |
+| [ovstorage](https://github.com/NVIDIA-Omniverse/ovstorage) | Agent-first, plugin-based storage client for local files, cloud object stores, and Omniverse Storage services. |
+| [ovpackage](https://github.com/NVIDIA-Omniverse/ovpackage) | Command-line tool and async Python API for reproducible asset packaging and publishing across local and cloud storage backends. |
+
+## OpenUSD Tooling and SDKs
+
+Libraries and services for authoring, validating, converting, optimizing, and searching OpenUSD content:
+
+- [usd-exchange](https://github.com/NVIDIA-Omniverse/usd-exchange) — OpenUSD Exchange SDK for authoring consistent and correct USD ([samples](https://github.com/NVIDIA-Omniverse/usd-exchange-samples))
+- [usd-validation-nvidia](https://github.com/NVIDIA-Omniverse/usd-validation-nvidia) — extensible framework to validate OpenUSD assets
+- [usd-profiles-nvidia](https://github.com/NVIDIA-Omniverse/usd-profiles-nvidia) — framework for defining and managing OpenUSD asset profiles, capabilities, and requirements
+- [usd-optimize](https://github.com/NVIDIA-Omniverse/usd-optimize) — library to optimize OpenUSD stages
+- [usd-convert-asset](https://github.com/NVIDIA-Omniverse/usd-convert-asset), [usd-convert-cad](https://github.com/NVIDIA-Omniverse/usd-convert-cad), and [usd-convert-gsplat](https://github.com/NVIDIA-Omniverse/usd-convert-gsplat) — converters for common asset formats, CAD data, and 3D Gaussian Splats
+- [usd-search](https://github.com/NVIDIA-Omniverse/usd-search) — cloud-native microservices for searching OpenUSD asset collections by natural language or reference image ([client library](https://github.com/NVIDIA-Omniverse/usdsearch-client))
+- [omniverse-labs](https://github.com/NVIDIA-Omniverse/omniverse-labs) — experimental Omniverse projects, including the nanousd family of lightweight USD tools
 
 ## Agent Skills and MCP Servers
 
@@ -14,8 +33,12 @@ Agent Skills and MCP (Model Context Protocol) servers help AI coding assistants 
 
 | Name | Type | Description | Repository |
 |------|------|-------------|------------|
-| **ovrtx** | Agent Skills | Omniverse RTX SDK — renderer setup, USD scene loading, rendering, attribute writing, CUDA/Vulkan interop, and project scaffolding. | [NVIDIA-Omniverse/ovrtx/skills/](https://github.com/NVIDIA-Omniverse/ovrtx/tree/main/skills) |
-| **ovphysx** | Agent Skills | USD physics simulation — C API with Python bindings, DLPack tensor interop, environment cloning for batched RL, and rigid body simulation. | [NVIDIA-Omniverse/PhysX/ovphysx/](https://github.com/NVIDIA-Omniverse/PhysX/tree/main/ovphysx) |
+| **ovrtx** | Agent Skills | Omniverse RTX SDK — renderer setup, USD scene loading, rendering, attribute writing, CUDA/Vulkan interop, and project scaffolding. | [ovrtx/skills/](https://github.com/NVIDIA-Omniverse/ovrtx/tree/main/skills) |
+| **ovphysx** | Agent Skills | USD physics simulation — C API with Python bindings, DLPack tensor interop, environment cloning for batched RL, and rigid body simulation. | [PhysX/ovphysx/](https://github.com/NVIDIA-Omniverse/PhysX/tree/main/ovphysx) |
+| **ovui** | Agent Skills | Standalone omni.ui framework — declarative Python UI building, widgets, layout, and styling. | [ovui/skills/](https://github.com/NVIDIA-Omniverse/ovui/tree/main/skills) |
+| **ovstream** | Agent Skills | Streaming library — video, audio, and input streaming over WebRTC, RTSP, native, and shared-memory transports. | [ovstream/skills/](https://github.com/NVIDIA-Omniverse/ovstream/tree/main/skills) |
+| **ovstorage** | Agent Skills | Storage client — local files, cloud object stores, and Omniverse Storage services. | [ovstorage/skills/](https://github.com/NVIDIA-Omniverse/ovstorage/tree/main/skills) |
+| **ovpackage** | Agent Skills | Asset packaging and publishing — CLI and Python API workflows. | [ovpackage/.agents/skills/](https://github.com/NVIDIA-Omniverse/ovpackage/tree/main/.agents/skills) |
 | **Kit MCP** | MCP Server | Kit development assistant — semantic search across 400+ extensions, dependency graphs, API docs, code examples, and app templates. | [kit-usd-agents/source/mcp/kit_mcp/](https://github.com/NVIDIA-Omniverse/kit-usd-agents/tree/main/source/mcp/kit_mcp) |
 | **USD Code MCP** | MCP Server | USD/OpenUSD development assistant — module and class browsing, method signatures, code examples, and semantic search. | [kit-usd-agents/source/mcp/usd_code_mcp/](https://github.com/NVIDIA-Omniverse/kit-usd-agents/tree/main/source/mcp/usd_code_mcp) |
 | **OmniUI MCP** | MCP Server | OmniUI development assistant — class and module browsing, method docs, code examples, and system instructions. | [kit-usd-agents/source/mcp/omni_ui_mcp/](https://github.com/NVIDIA-Omniverse/kit-usd-agents/tree/main/source/mcp/omni_ui_mcp) |
@@ -35,6 +58,12 @@ The following NVIDIA Physical AI skills are available:
 These skills are also available in [Vercel's Skill Marketplace](https://www.skills.sh/nvidia/skills) under the Physical AI section, and as plugins in the Claude Code marketplace and Codex marketplace.
 
 See also the [NVIDIA Agent Skills catalog](https://github.com/NVIDIA/skills) for skills across the NVIDIA ecosystem.
+
+## Blueprints and Workflows
+Omniverse Workflows and Blueprints provide step-by-step guides and reference implementations for a variety of development scenarios. They can help you get started quickly with use cases such as virtual facility integration (VFI), configurator development, synthetic data generation, and more. These resources build on repositories in this Omniverse GitHub organization.
+
+- [Blueprints and Workflows Documentation](https://docs.nvidia.com/omniverse/index.html#blueprints-workflows)
+- [NVIDIA-Omniverse-blueprints on GitHub](https://github.com/NVIDIA-Omniverse-blueprints)
 
 ## Additional Resources
 


### PR DESCRIPTION
Add an Omniverse Libraries section covering ovrtx, ovphysx, ovui, ovstream, ovstorage, and ovpackage; add an OpenUSD tooling section; extend the Agent Skills table with the ovui/ovstream/ovstorage skills. Move blueprints down.